### PR TITLE
Change SDSS pin number for Printrboard.

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -1471,7 +1471,7 @@
 #define TEMP_2_PIN         -1
 
 #define SDPOWER            -1
-#define SDSS                8
+#define SDSS               26 //QU-BD_Ups SD Chip Select
 #define LED_PIN            -1
 #define PS_ON_PIN          -1
 #define KILL_PIN           -1


### PR DESCRIPTION
Like the fan, the code in Marlin does not seem to use fastio to communicate with the SD Card, so the pin numbering is the same as the Teensy++2.0. Fastio, for whatever reason, scrambles the IO pin numbers. See https://github.com/ErikZalm/Marlin/issues/112.

The SD Chip Select is connected to Port B pin 6, which is pin 26 in Teensyduino-land. 

For some reason, this pin was set to 8, which isn't B6 in either Teensyduinoland or Fastio-mangled-Teensyduinoland.
