### PR TITLE
Added better relay support for controller fan switching

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -63,8 +63,8 @@
 //and turn off after the set amount of seconds from last driver being disabled again
 #define CONTROLLERFAN_PIN -1 //Pin used for the fan to cool controller (-1 to disable)
 #define CONTROLLERFAN_SECS 60 //How many seconds, after all motors were disabled, the fan should run
-#define CONTROLLERFAN_ON 255  //Value for switching controller fan ON (0 for active low, 1-255 for active high switching)
-#define CONTROLLERFAN_OFF 0  //Value for switching controller fan OFF (1-255 for active low, 0 for active high switching)
+#define CONTROLLERFAN_ON 255  //Value for switching controller fan ON (0 for active low, 255 for active high switching)
+#define CONTROLLERFAN_OFF 0  //Value for switching controller fan OFF (255 for active low, 0 for active high switching)
 
 // When first starting the main fan, run it at full speed for the
 // given number of milliseconds.  This gets the fan spinning reliably

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -63,7 +63,8 @@
 //and turn off after the set amount of seconds from last driver being disabled again
 #define CONTROLLERFAN_PIN -1 //Pin used for the fan to cool controller (-1 to disable)
 #define CONTROLLERFAN_SECS 60 //How many seconds, after all motors were disabled, the fan should run
-#define CONTROLLERFAN_SPEED 255  // == full speed
+#define CONTROLLERFAN_ON 255  //Value for switching controller fan ON (0 for active low, 255 for active hgh switching)
+#define CONTROLLERFAN_OFF 0  //Value for switching controller fan OFF (255 for active low, 0 for active hgh switching)
 
 // When first starting the main fan, run it at full speed for the
 // given number of milliseconds.  This gets the fan spinning reliably

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -63,8 +63,8 @@
 //and turn off after the set amount of seconds from last driver being disabled again
 #define CONTROLLERFAN_PIN -1 //Pin used for the fan to cool controller (-1 to disable)
 #define CONTROLLERFAN_SECS 60 //How many seconds, after all motors were disabled, the fan should run
-#define CONTROLLERFAN_ON 255  //Value for switching controller fan ON (0 for active low, 255 for active hgh switching)
-#define CONTROLLERFAN_OFF 0  //Value for switching controller fan OFF (255 for active low, 0 for active hgh switching)
+#define CONTROLLERFAN_ON 255  //Value for switching controller fan ON (0 for active low, 1-255 for active high switching)
+#define CONTROLLERFAN_OFF 0  //Value for switching controller fan OFF (1-255 for active low, 0 for active high switching)
 
 // When first starting the main fan, run it at full speed for the
 // given number of milliseconds.  This gets the fan spinning reliably

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3208,14 +3208,14 @@ void controllerFan()
 
     if ((millis() - lastMotor) >= (CONTROLLERFAN_SECS*1000UL) || lastMotor == 0) //If the last time any driver was enabled, is longer since than CONTROLLERSEC...
     {
-        digitalWrite(CONTROLLERFAN_PIN, 0);
-        analogWrite(CONTROLLERFAN_PIN, 0);
+        digitalWrite(CONTROLLERFAN_PIN, CONTROLLERFAN_OFF);
+        analogWrite(CONTROLLERFAN_PIN, CONTROLLERFAN_OFF);
     }
     else
     {
         // allows digital or PWM fan output to be used (see M42 handling)
-        digitalWrite(CONTROLLERFAN_PIN, CONTROLLERFAN_SPEED);
-        analogWrite(CONTROLLERFAN_PIN, CONTROLLERFAN_SPEED);
+        digitalWrite(CONTROLLERFAN_PIN, CONTROLLERFAN_ON);
+        analogWrite(CONTROLLERFAN_PIN, CONTROLLERFAN_ON);
     }
   }
 }


### PR DESCRIPTION
replaced CONTROLLERFAN_SPEED with CONTROLLERFAN_OFF and
CONTROLLERFAN_ON. It still uses the same 0-255 value range, and will
still behave the same way when simply selecting a pin for switching,

Since the 5v signal will be used primarily for switching, this allows
for setting the on state as needed for relays that require Active Low
signals for activation.

It replaces the hardcoded 0 (off) value with CONTROLLERFAN_OFF which can
be defined by the user.
